### PR TITLE
Update source_hash

### DIFF
--- a/upstream.wrap
+++ b/upstream.wrap
@@ -3,4 +3,4 @@ directory = box2d-2.3.1
 
 source_url = https://github.com/erincatto/box2d/archive/v2.3.1/box2d-2.3.1.tar.gz
 source_filename = box2d-2.3.1.tar.gz
-source_hash = c18349cb2a64e76d0c3efb9e51feea97e8f858371140050bd423fc5d41aa13a4
+source_hash = 75d62738b13d2836cd56647581b6e574d4005a6e077ddefa5d727d445d649752


### PR DESCRIPTION
Updated the source_hash to be correct.

$ sha256sum box2d-2.3.1.tar.gz
75d62738b13d2836cd56647581b6e574d4005a6e077ddefa5d727d445d649752  box2d-2.3.1.tar.gz